### PR TITLE
feat: add herma 4346 labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Currently tested and known working are:
 - Avery L4731 (189 Labels on DIN A4)
 - Herma 4201 (64 Labels on DIN A4, [Disclaimer: Not perfect ;)](https://github.com/entropia/paperless-asn-qr-codes/pull/36))
 - Herma 10003 (80 Labels on DIN A4, formerly Herma 4345)
+- Herma 4346 (DIN A4 Labels)
 
 ## Tips & Tricks
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  --format {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371,herma10003}, -f {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371,herma10003}
+  --format {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371,herma10003,herma4346}, -f {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371,herma10003,herma4346}
   --digits DIGITS, -d DIGITS
                         Number of digits in the ASN (default: 7, produces 'ASN0000001')
   --border, -b          Display borders around labels, useful for debugging the printer alignment
@@ -67,7 +67,7 @@ Currently tested and known working are:
 - Avery L4731 (189 Labels on DIN A4)
 - Herma 4201 (64 Labels on DIN A4, [Disclaimer: Not perfect ;)](https://github.com/entropia/paperless-asn-qr-codes/pull/36))
 - Herma 10003 (80 Labels on DIN A4, formerly Herma 4345)
-- Herma 4346 (DIN A4 Labels)
+- Herma 4346 (48 Labels on DIN A4)
 
 ## Tips & Tricks
 

--- a/paperless_asn_qr_codes/avery_labels.py
+++ b/paperless_asn_qr_codes/avery_labels.py
@@ -108,6 +108,14 @@ labelInfo: dict[str, LabelInfo] = {
         margin=(11.02 * mm, 13.06 * mm),
         pagesize=A4,
     ),
+    "herma4346": LabelInfo(
+        labels_horizontal=4,
+        labels_vertical=12,
+        label_size=(45.72*mm, 21.167*mm),
+        gutter_size=(2.54*mm, 0),
+        margin=(9.75*mm,21.5*mm),
+        pagesize=A4,
+    )
 }
 
 RETURN_ADDRESS = 5167


### PR DESCRIPTION
Hi, 
I added the herma 4346 labels. They print okay - everything is on the label. The first row prints at the bottom of the label, the last row at the very top. But I think it's a general issue - as the measurements are very precise.

Thank you for your great work