### PR TITLE
Add `--digits` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   --format {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371}, -f {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371}
+  --digits DIGITS, -d DIGITS
+                        Number of digits in the ASN (default: 7, produces 'ASN0000001')
   --border, -b          Display borders around labels, useful for debugging the printer alignment
 ```
 
@@ -39,6 +41,7 @@ options:
 
 - `-h`, `--help`: Shows the help message
 - `-f`, `--format`: Selects the format of the output sheet (see [Supported Sheets](#supported-sheets))
+- `-d`, `--digits`: Specifies the number of digits in the ASN (e.g. for the default number 7, the ASN will look like 'ASN0000001')
 - `-b`, `--border`: Generates the borders around the labels to help debug alignment issues (see [Tips & Tricks](#tips--tricks))
 
 ## Supported Sheets

--- a/paperless_asn_qr_codes/main.py
+++ b/paperless_asn_qr_codes/main.py
@@ -8,7 +8,8 @@ from paperless_asn_qr_codes import avery_labels
 
 def render(c, x, y):
     global startASN
-    barcode_value = f"ASN{startASN:07d}"
+    global digits
+    barcode_value = f"ASN{startASN:0{digits}d}"
     startASN = startASN + 1
 
     qr = QRCodeImage(barcode_value, size=y * 0.9)
@@ -28,6 +29,9 @@ def main():
         "--format", "-f", choices=avery_labels.labelInfo.keys(), default="averyL4731"
     )
     parser.add_argument(
+        "--digits", "-d", default=7, help="Number of digits in the ASN (default: 7, produces 'ASN0000001')", type=int
+    )
+    parser.add_argument(
         "--border",
         "-b",
         action="store_true",
@@ -35,7 +39,9 @@ def main():
     )
     args = parser.parse_args()
     global startASN
+    global digits
     startASN = int(args.start_asn)
+    digits = int(args.digits)
     label = avery_labels.AveryLabel(args.format, args.border)
     label.open(args.output_file)
     # by default, we render all labels possible on a single sheet


### PR DESCRIPTION
to allow configuring the number of digits in the ASN string. This argument is optional and defaults to 7 to keep backwards compatibility.