### PR TITLE
Correct gutter size and margin on avery5167

### DIFF
--- a/paperless_asn_qr_codes/avery_labels.py
+++ b/paperless_asn_qr_codes/avery_labels.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass, KW_ONLY
 from collections.abc import Iterator
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import LETTER, A4
-from reportlab.lib.units import mm
+from reportlab.lib.units import mm, inch
+
 
 # Usage:
 #   label = AveryLabels.AveryLabel(5160)
@@ -67,9 +68,9 @@ labelInfo: dict[str, LabelInfo] = {
     "avery5167": LabelInfo(
         labels_horizontal=4,
         labels_vertical=20,
-        label_size=(126, 36),
-        gutter_size=(0, 0),
-        margin=(54, 36),
+        label_size=(1.75 * inch, 0.5 * inch),
+        gutter_size=(0.3 * inch, 0),
+        margin=(0.3 * inch, 0.5 * inch),
         pagesize=LETTER,
     ),
     # 3.5 x 2 business cards


### PR DESCRIPTION
Using the official Avery PDF and DOC templates, I was able to correct the dimensions for the margin, and implement gutter size for Avery 5167. I've also changed the label sizes to use the `inch` attribute from `reportlab` in order to make things easier to audit (The labeling for that product seems to be in inches).

Tested using a combination of:
* Official templates from Avery website (DOC, PDF)
* `paperless-asn-qr-codes --format avery5167 --border 1 avery5167.pdf` and the Avery 5167 product itself for manual comparison