### PR TITLE
deps: drop argparse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "argparse",
   "reportlab",
   "reportlab_qrcode"
 ]


### PR DESCRIPTION
argparse is part of the python standard library since python 3.2, this project is targeting at least python 3.7.

https://pypi.org/project/argparse/