### PR TITLE
Add HERMA 10003/4345 labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The default is Avery L4731.
 Currently tested and known working are:
 - Avery L4731 (189 Labels on DIN A4)
 - Herma 4201 (64 Labels on DIN A4, [Disclaimer: Not perfect ;)](https://github.com/entropia/paperless-asn-qr-codes/pull/36))
-- HERMA 10003 (formerly HERMA 4345)
+- Herma 10003 (80 Labels on DIN A4, formerly Herma 4345)
 
 ## Tips & Tricks
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ pip install paperless-asn-qr-codes
 ## Usage
 
 ```
-usage: paperless-asn-qr-codes [-h] [--format {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371}] [--digits DIGITS] [--border] [--row-wise] [--num-labels NUM_LABELS] [--pages PAGES]
+usage: paperless-asn-qr-codes [-h] [--format {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371,herma10003}]
+                              [--digits DIGITS] [--border] [--row-wise] [--num-labels NUM_LABELS] [--pages PAGES]
                               [--start-position START_POSITION]
                               start_asn output_file
 
@@ -25,7 +26,7 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  --format {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371}, -f {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371}
+  --format {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371,herma10003}, -f {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371,herma10003}
   --digits DIGITS, -d DIGITS
                         Number of digits in the ASN (default: 7, produces 'ASN0000001')
   --border, -b          Display borders around labels, useful for debugging the printer alignment
@@ -65,6 +66,7 @@ The default is Avery L4731.
 Currently tested and known working are:
 - Avery L4731 (189 Labels on DIN A4)
 - Herma 4201 (64 Labels on DIN A4, [Disclaimer: Not perfect ;)](https://github.com/entropia/paperless-asn-qr-codes/pull/36))
+- HERMA 10003 (formerly HERMA 4345)
 
 ## Tips & Tricks
 

--- a/paperless_asn_qr_codes/avery_labels.py
+++ b/paperless_asn_qr_codes/avery_labels.py
@@ -99,6 +99,15 @@ labelInfo: dict[str, LabelInfo] = {
         margin=(8 * mm, 13 * mm),
         pagesize=A4,
     ),
+    # HERMA No. 10003 labels (former article No. 4345)
+    "herma10003": LabelInfo(
+        labels_horizontal=5,
+        labels_vertical=16,
+        label_size=(35.56 * mm, 16.93 * mm),
+        gutter_size=(2.54 * mm, 0),
+        margin=(11.02 * mm, 13.06 * mm),
+        pagesize=A4,
+    ),
 }
 
 RETURN_ADDRESS = 5167


### PR DESCRIPTION
Hi,
this PR adds the Label Info for HERMA 10003 (formerly called HERMA 4345) labels.
These are 35.6 x 16.8 mm labels (80 per A4 sheet) I use for my paperless-ngx workflow.

Measurements are taken from the API that works in the background of their online label assistant.

As this prints fine, and as recommended in a similar PR https://github.com/entropia/paperless-asn-qr-codes/pull/12#pullrequestreview-2006957806, I also felt free to add this to the Supported Sheets sections.
I also updated the usage section in the docs with the added format.

Thank you for your great project!