### PR TITLE
Add support for Avery L4732 labels

### DIFF
--- a/paperless_asn_qr_codes/avery_labels.py
+++ b/paperless_asn_qr_codes/avery_labels.py
@@ -38,6 +38,14 @@ labelInfo: dict[str, LabelInfo] = {
         margin=(9 * mm, 13.5 * mm),
         pagesize=A4,
     ),
+    "averyL4732": LabelInfo(
+        labels_horizontal=5,
+        labels_vertical=16,
+        label_size=(35.6 * mm, 16.9 * mm),
+        gutter_size=(2.5 * mm, 0),
+        margin=(11 * mm, 13.5 * mm),
+        pagesize=A4,
+    ),
     # 2.6 x 1 address labels
     "avery5160": LabelInfo(
         labels_horizontal=3,


### PR DESCRIPTION
This adds support for Avery L4732 labels. These are A4 labels and a larger than Avery L4731 labels – there are 80 per sheet.