### PR TITLE
Add Avery L6026 labels and variable bigger font

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  --format {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371}, -f {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371}
+  --format {averyL4731, averyL6026, avery5160,avery5161,avery5163,avery5167,avery5371}, -f {averyL4731,avery5160,avery5161,avery5163,avery5167,avery5371}
   --digits DIGITS, -d DIGITS
                         Number of digits in the ASN (default: 7, produces 'ASN0000001')
   --border, -b          Display borders around labels, useful for debugging the printer alignment
@@ -56,6 +56,8 @@ options:
 - `-n`, `--num-labels`: Number of lables to be printed on the sheet
 - `-p`, `--pages`: Number of pages to be generated, ignored if -n is present.
 - `-s`, `--start-position`: Positon of first label to be printed, eighter defined as ROW:COLUMN or NUMBER. Starting from 1 eg. to use the whole sheet it would be 1:1 or 1. Useful if you have a partly used sheet from using `-n`.
+- `-l`, `--line-break`: Break line after ASN and display number in new line (default `false`)
+- `-z`, `--size`: Font size for the printed number (default 2 mm)
 
 ## Supported Sheets
 Some different sheet types are supported with the `-f`/`--format` argument, however, not all are tested.
@@ -64,6 +66,7 @@ The default is Avery L4731.
 
 Currently tested and known working are:
 - Avery L4731 (DIN A4 Labels)
+- Avery L6026 (DIN A4 Labels)
 
 ## Tips & Tricks
 

--- a/paperless_asn_qr_codes/avery_labels.py
+++ b/paperless_asn_qr_codes/avery_labels.py
@@ -38,6 +38,14 @@ labelInfo: dict[str, LabelInfo] = {
         margin=(9 * mm, 13.5 * mm),
         pagesize=A4,
     ),
+    "averyL6026": LabelInfo(
+        labels_horizontal=5,
+        labels_vertical=13,
+        label_size=(38.1 * mm, 21.2 * mm),
+        gutter_size=(2.5 * mm, 0),
+        margin=(5 * mm, 11.9 * mm),
+        pagesize=A4,
+    ),
     # 2.6 x 1 address labels
     "avery5160": LabelInfo(
         labels_horizontal=3,


### PR DESCRIPTION
The small labels are difficult to read for people with impaired eyesight, therefore I added and test-printed labels for Avery L6026REV. Because those labels are bigger I added two more command inputs for scaling the font size and for having a line break after ASN. In general this makes it easier to read bigger labels.