### PR TITLE
Add definition for Herma 4201 45.7x16.9mm labels

### DIFF
--- a/paperless_asn_qr_codes/avery_labels.py
+++ b/paperless_asn_qr_codes/avery_labels.py
@@ -82,6 +82,15 @@ labelInfo: dict[str, LabelInfo] = {
         margin=(54, 36),
         pagesize=LETTER,
     ),
+    # Herma 4201, 64 removable labels
+    "herma4201": LabelInfo(
+        labels_horizontal=4,
+        labels_vertical=16,
+        label_size=(45.7 * mm, 16.9 * mm),
+        gutter_size=(2.5 * mm, 0),
+        margin=(8 * mm, 13 * mm),
+        pagesize=A4,
+    ),
 }
 
 RETURN_ADDRESS = 5167


### PR DESCRIPTION
Hey there, thank you a lot for your work on the label generator, it has helped me tremendously finally setting up my paperless-ngx workflow :)

I added the definition for Herma 4201 removable labels (64 labels at 45.7x16.9mm per sheet). They are not picture perfect, but have been shown to print on different cursed printers without overshooting the label boundaries ;)