### PR TITLE
fix: dev version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ paperless-asn-qr-codes = "paperless_asn_qr_codes.main:main"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
+
 [tool.hatch.envs.ci]
 dependencies = [
   "pylint",


### PR DESCRIPTION
With this PR, it should be possible that dev versions are published for easier usage of unreleased features (see https://github.com/ofek/hatch-vcs/discussions/12)