### PR TITLE
Add Avery 3657 definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The default is Avery L4731.
 Currently tested and known working are:
 - **Avery L4731 (189 Labels on DIN A4, the default)**
 - Avery L4732 (80 Labels on DIN A4)
+- Avery 3657 (40 Labels on DIN A4)
 - Herma 10003 (80 Labels on DIN A4, formerly Herma 4345)
 - Herma 4201 (64 Labels on DIN A4, [Disclaimer: Not perfect ;)](https://github.com/entropia/paperless-asn-qr-codes/pull/36))
 - Herma 4346 (48 Labels on DIN A4)

--- a/paperless_asn_qr_codes/avery_labels.py
+++ b/paperless_asn_qr_codes/avery_labels.py
@@ -117,6 +117,15 @@ labelInfo: dict[str, LabelInfo] = {
         gutter_size=(2.54*mm, 0),
         margin=(9.75*mm,21.5*mm),
         pagesize=A4,
+    ),
+    # AVERY 3657 (48.5mm x 25.4mm)
+    "avery3657": LabelInfo(
+        labels_horizontal=4,
+        labels_vertical=10,
+        label_size=(48.5*mm, 25.4*mm),
+        gutter_size=(0, 0),
+        margin=(8*mm,21.75*mm),
+        pagesize=A4,
     )
 }
 


### PR DESCRIPTION
This commit adds label definition for Avery 3657 labels.
The labels are 48.5x25.4mm, there are 40 on a page.

Test prints were done and are working.