### PR TITLE
added averyL7658

### DIFF
--- a/paperless_asn_qr_codes/avery_labels.py
+++ b/paperless_asn_qr_codes/avery_labels.py
@@ -48,6 +48,14 @@ labelInfo: dict[str, LabelInfo] = {
         margin=(11 * mm, 13.5 * mm),
         pagesize=A4,
     ),
+    "averyL7658": LabelInfo(
+        labels_horizontal=7,
+        labels_vertical=27,
+        label_size=(25.4 * mm, 10 * mm),
+        gutter_size=(2.5 * mm, 0.07 * mm),
+        margin=(9 * mm, 12.5 * mm),
+        pagesize=A4,
+    ),
     # 2.6 x 1 address labels
     "avery5160": LabelInfo(
         labels_horizontal=3,


### PR DESCRIPTION
Hi,
I added Support for Avery L7658 Labels.

I could not directly use them as my printer was always scaling. According to the acrobat measurement tools, it should fit. I measured in acrobat and on the physical sheets. But my Samsung printer made something different (used other values and a sclaing setting).

I don't want to use MY specific printer settings in the code. Feel free to reject the PR, if you want to see it working, before merging...

Regards
Philipp