### PR TITLE
add support for avery5195 labels

### DIFF
--- a/paperless_asn_qr_codes/avery_labels.py
+++ b/paperless_asn_qr_codes/avery_labels.py
@@ -93,6 +93,16 @@ labelInfo: dict[str, LabelInfo] = {
         margin=(0.3 * inch, 0.5 * inch),
         pagesize=LETTER,
     ),
+    # 1.75 x 0.66 return address labels
+    "avery5195": LabelInfo(
+        labels_horizontal=4,
+        labels_vertical=15,
+        label_size=(128, 47),
+        gutter_size=(20, 0),
+        margin=(19, 38.5),
+        pagesize=LETTER,
+        textsize=3 * mm,
+    ),
     # 3.5 x 2 business cards
     "avery5371": LabelInfo(
         labels_horizontal=2,


### PR DESCRIPTION
# Description
Add support for Avery5195 labels

# Testing Done
Printed physical copy and verified the label and text size is within label border, using Brother HL-2790DW printer w/ margins set to 0.